### PR TITLE
RLAU-303 seeded key pair

### DIFF
--- a/src/modules/account/RadixAccount.ts
+++ b/src/modules/account/RadixAccount.ts
@@ -11,7 +11,7 @@ import { RadixAccountSystem,
     radixUniverse,
     RadixNodeConnection,
     RadixDecryptionProvider,
-
+    RadixUtil
  } from '../..'
 
 
@@ -65,6 +65,21 @@ export default class RadixAccount {
      */
     public static fromAddress(address: string, plain = false) {
         return new RadixAccount(RadixAddress.fromAddress(address), plain)
+    }
+
+    /**
+     * Create an instance of a Radix account from an arbitrary byte buffer. This
+     * could e.g. be a friendly name of an account, in which case it would be
+     * created as <code>Buffer.from('friendly name')</code>.
+     *
+     * @param seed Buffer seed for the address
+     * @param [plain] If set to true, will not create default account systems.
+     * Use this for accounts that will not be connected to the network.
+     * @returns a new Radix account. 
+     */
+    public static fromSeed(seed: Buffer, plain = false) {
+        const hash = RadixUtil.hash(seed)
+        return new RadixAccount(RadixAddress.fromPrivate(hash), plain)
     }
 
     public enableDecryption(decryptionProvider: RadixDecryptionProvider) {

--- a/src/modules/identity/RadixSimpleIdentity.ts
+++ b/src/modules/identity/RadixSimpleIdentity.ts
@@ -2,10 +2,24 @@ import RadixECIES from '../crypto/RadixECIES'
 import RadixIdentity from './RadixIdentity'
 
 import { RadixAtom, RadixAddress } from '../atommodel'
+import { RadixUtil } from '../..'
 
 export default class RadixSimpleIdentity extends RadixIdentity {
     constructor(readonly address: RadixAddress) {
         super(address)
+    }
+
+    /**
+     * Create an instance of a Radix simple identity from an arbitrary byte
+     * buffer. This could e.g. be a friendly name of an account, in which
+     * case it would be created as <code>Buffer.from('friendly name')</code>.
+     *
+     * @param seed Buffer seed for the address
+     * @returns a new Radix account. 
+     */
+    public static fromSeed(seed: Buffer) {
+        const hash = RadixUtil.hash(seed)
+        return new RadixSimpleIdentity(RadixAddress.fromPrivate(hash))
     }
 
     public async signAtom(atom: RadixAtom) {


### PR DESCRIPTION
This change makes it possible to create a Radix account or a Radix
simple identity based on a seeded key pair.