### PR TITLE
alphanet2: use real node names instead of going through reverse proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "bufferutil": "^4.0.0",
     "decimal.js": "^10.0.1",
     "elliptic": "^6.4.1",
+    "ipaddr.js": "^1.9.0",
     "loglevel": "^1.6.1",
     "long": "^4.0.0",
     "nedb": "^1.8.0",

--- a/src/modules/universe/RadixUniverse.spec.ts
+++ b/src/modules/universe/RadixUniverse.spec.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai'
+import 'mocha'
+
+import RadixUniverse from '../universe/RadixUniverse'
+
+
+describe('Radix Universe', () => {
+    it('resolveNodeName function should support IPv4', () => {
+        expect(RadixUniverse.resolveNodeName("127.0.0.1")).to.equal("az8kflt.radixnode.net")
+    })
+    it('resolveNodeName function should not break by unsupported IPv6 addresses', () => {
+        expect(RadixUniverse.resolveNodeName("::1")).to.equal("[::1]")
+    })
+    it('resolveNodeName function should let hostnames through without modification', () => {
+        expect(RadixUniverse.resolveNodeName("foo")).to.equal("foo")
+    })
+    it('ALPHANET2 config should access nodes directly by DNS name', () => {
+        const cfg = RadixUniverse.ALPHANET2
+        expect(cfg.nodeRPCAddress("127.0.0.1")).to.equal("wss://az8kflt.radixnode.net/rpc")
+        expect(cfg.nodeDiscovery.nodeRPCAddress("127.0.0.1"))
+            .to.equal("https://az8kflt.radixnode.net/rpc")
+    })
+})

--- a/src/modules/universe/RadixUniverse.spec.ts
+++ b/src/modules/universe/RadixUniverse.spec.ts
@@ -7,6 +7,7 @@ import RadixUniverse from '../universe/RadixUniverse'
 describe('Radix Universe', () => {
     it('resolveNodeName function should support IPv4', () => {
         expect(RadixUniverse.resolveNodeName("127.0.0.1")).to.equal("az8kflt.radixnode.net")
+        expect(RadixUniverse.resolveNodeName("128.0.0.1")).to.equal("azik0zl.radixnode.net")
     })
     it('resolveNodeName function should not break by unsupported IPv6 addresses', () => {
         expect(RadixUniverse.resolveNodeName("::1")).to.equal("[::1]")

--- a/src/modules/universe/RadixUniverse.ts
+++ b/src/modules/universe/RadixUniverse.ts
@@ -97,7 +97,10 @@ export default class RadixUniverse {
         try {
             const ipbytes = ipaddr.parse(address).toByteArray();
             if (ipbytes.length == 4) { // IPv4
-                let ip = ipbytes[3] | (ipbytes[2] << 8) | (ipbytes[1] << 16) | (ipbytes[0] << 24)
+                // trivial but safe left-shift function that does not overflow
+                const shl = (base, exp) => base * Math.pow(2, exp)
+                // use + instead of | (bitwise or) because it overflows
+                let ip = ipbytes[3] + shl(ipbytes[2], 8) + shl(ipbytes[1], 16) + shl(ipbytes[0], 24)
                 return `a${ip.toString(36)}.radixnode.net`
             }
             logger.warn('No base36 encoder for IPv6 yet')


### PR DESCRIPTION
Going through the reverse proxy @ alphanet2.radixdlt.com is very
risky (centralised). We need to start using valid node names asap.

Professional node-runners are expected to setup their own DNS records,
which is why the resolveNodeName should allow those to pass through
as well.

**NOTE**: In regards to IPv6, which is not supported for alphanet2, the
resolveNodeName function will not calculate a valid node name at this
point. This will be fixed at a later time.